### PR TITLE
Bash 4.x error message fails to print.

### DIFF
--- a/gherkin
+++ b/gherkin
@@ -12,7 +12,7 @@ usage() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" != 4 ]]; then
-  echo "bash >= 4.0.0 required" >2&
+  echo "bash >= 4.0.0 required" >&2
   exit 1
 fi
 


### PR DESCRIPTION
A typo on the redirect to stdout ate the error message.
