### PR TITLE
Tweaks/hacks for using gherkin as in interpereter in another script.

### DIFF
--- a/gherkin
+++ b/gherkin
@@ -1252,6 +1252,7 @@ eval_string() {
 # Start REPL if no arguments
 [ -z "$*" ] && repl
 
+ARGV="$*"
 # Process parameters
 while [ "$*" ]; do
   param=$1; shift; OPTARG=$1

--- a/gherkin
+++ b/gherkin
@@ -79,7 +79,7 @@ ungetc() {
   fi
 }
 
-has_shebangP() { [[ "$(head -1 $1)" =~ ^#! ]]; }
+has_shebangP() { [[ "$(head -1 $1)" =~ ^#! && "$(head -1 $1)" =~ gherkin ]]; }
 
 strmap_file() {
   local f="$1" contents
@@ -1265,7 +1265,7 @@ while [ "$*" ]; do
     -t|--test) ;;
     -r|--repl) repl ;;
     -*) usage ;;
-    *)         eval_file "$param"
+    *)         [[ -f "$param" ]] && has_shebangP "$param" && eval_file "$param"
                [[ $r != $NIL ]] && prn $r
                ;;
   esac


### PR DESCRIPTION
Stops gherkin trying to run commands that are passed to a script that is using gherkin as an interpreter, and includes a hack to make args available via (getenv ARGV).